### PR TITLE
explicit bool types to int types

### DIFF
--- a/cligen.nim
+++ b/cligen.nim
@@ -515,7 +515,7 @@ macro dispatchGen*(pro: typed{nkSym}, cmdName: string="", doc: string="",
         let hlp = helps.getOrDefault(pNm)[1]
         let isReq = if i in mandatory: true else: false
         result.add(quote do:
-         `apId`.parNm = `parNm`; `apId`.parSh = `sh`; `apId`.parReq = `isReq`
+         `apId`.parNm = `parNm`; `apId`.parSh = `sh`; `apId`.parReq = ord(`isReq`)
          `apId`.parRend = if `hky`.len>0: `hky` else:helpCase(`parNm`,clLongOpt)
          let descr = getDescription(`defVal`, `parNm`, `hlp`)
          if descr != `cf`.hTabSuppress:


### PR DESCRIPTION
taken from c-blake/cligen#221
currently trying to build [disruptek/bump](https://github.com/disruptek/bump) with Nim 1.9.1 fails with
```sh
cligen.nim(517, 20) Error: type mismatch: got 'bool' for 'false' but expected 'int'
```
This pr fixes the error.